### PR TITLE
fix CRLR discrepancy in resources

### DIFF
--- a/dev/resource_packager.js
+++ b/dev/resource_packager.js
@@ -56,10 +56,23 @@ for (var i = 0; i < resourceDirectories.length; i++) {
 	}
 }
 
-var resourceJavascriptFile = "var Resources = " + JSON.stringify(resourcePackage, null, 2) + ";";
+// console.log(resourcePackage);
+
+var str = JSON.stringify(resourcePackage, null, 2);
+
+function fixCRLR() {
+	str = str.replace(/\\r\\n/g, '\\n');
+	return str;
+}
+
+fixCRLR();
+
+// console.log(str);
+
+var resourceJavascriptFile = "var Resources = " + str + ";";
+
+// console.log(resourceJavascriptFile);
 
 fs.writeFile("../editor/script/generated/resources.js", resourceJavascriptFile, function () {});
-
-// console.log(resourcePackage);
 
 console.log("done!");


### PR DESCRIPTION
- added a function to the resource_packager.js to replace "\r\n" with "\n"
- ran the script again to generate an export template (among other files)  that would be compatible with other versions of Bitsy