### PR TITLE
polish paint tool and fix tile refresh

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -699,7 +699,9 @@
 						<div id="paintNavigationControls" class="navControl">
 							<!-- name -->
 							<input title="a name to refer to this drawing" type="text" id="drawingName" class="textInputField" onchange="on_drawing_name_change();"></input>
+						</div>
 
+						<div id="paintNavigationControls" class="navControl">
 							<!-- prev / next -->
 							<button title="previous drawing" class="color0 disableForAvatar" onclick="prev();">
 								<span class="bitsy_icon">previous</span>
@@ -731,65 +733,72 @@
 						<canvas id="paint"></canvas>
 
 						<!-- paint hacks -->
-						<div id="paintTransform">
-                            <div class="buttonGroup" style="margin-bottom: 5px; margin-right: 3px;">
-                                <button title="nudge left" class="color0" onclick="nudgeDrawing(0);">
-                                    <span class="bitsy_icon">previous</span>
-                                </button>
-                                <button title="nudge right" class="color0" onclick="nudgeDrawing(1);">
-                                    <span class="bitsy_icon">next</span>
-                                </button>
-                                <button title="nudge up" class="color0" onclick="nudgeDrawing(2);">
-                                    <span class="bitsy_icon">arrow_up</span>
-                                </button>
-                                <button title="nudge down" class="color0" onclick="nudgeDrawing(3);">
-                                    <span class="bitsy_icon">arrow_down</span>
-                                </button>
-                            </div>
-                            <div class="buttonGroup" style="margin-bottom: 5px; margin-right: 3px;">
-                                <button title="rotate clockwize" class="color0" onclick="rotateDrawing(1);">
-                                    <span class="bitsy_icon">rotate_right</span>
-                                </button>
-                                <button title="rotate counter-clockwize" class="color0" onclick="rotateDrawing(0);">
-                                    <span class="bitsy_icon">rotate_left</span>
-                                </button>
-                            </div>
-                        </div>
-                        <div id="paintMirror">
-                            <div class="buttonGroup" style="margin-bottom: 5px; margin-right: 3px;">
-                                <button title="mirror to right" class="color0" onclick="mirrorDrawing(1);">
-                                    <span class="bitsy_icon">mirror_right</span>
-                                </button>
-                                <button title="mirror to left" class="color0" onclick="mirrorDrawing(0);">
-                                    <span class="bitsy_icon">mirror_left</span>
-                                </button>
-                                <button title="mirror to down" class="color0" onclick="mirrorDrawing(3);">
-                                    <span class="bitsy_icon">mirror_down</span>
-                                </button>
-                                <button title="mirror to up" class="color0" onclick="mirrorDrawing(2);">
-                                    <span class="bitsy_icon">mirror_up</span>
-                                </button>
-                            </div>
-                            <div class="buttonGroup" style="margin-bottom: 5px; margin-right: 3px;">
-                                <button title="horizontal flip" class="color0" onclick="flipDrawing(1);">
-                                    <span class="bitsy_icon">flip_horizontal</span>
-                                </button>
-                                <button title="vertical flip" class="color0" onclick="flipDrawing(0);">
-                                    <span class="bitsy_icon">flip_vertical</span>
-                                </button>
-                            </div>
-                        </div>
-						<!-- paint hacks end -->
-						
-						<div id="paintEditMain">
-							<div class="buttonGroup">
+						<div id="paintTransform" class="navControl paintToolTop">
+                            <button title="nudge left" class="color0" onclick="nudgeDrawing(0);">
+                                <span class="bitsy_icon">previous</span>
+                            </button>
+
+                            <button title="nudge right" class="color0" onclick="nudgeDrawing(1);">
+                                <span class="bitsy_icon">next</span>
+                            </button>
+
+                            <button title="nudge up" class="color0" onclick="nudgeDrawing(2);">
+                                <span class="bitsy_icon">arrow_up</span>
+                            </button>
+
+                            <button title="nudge down" class="color0" onclick="nudgeDrawing(3);">
+                                <span class="bitsy_icon">arrow_down</span>
+                            </button>
+
+                            <button title="rotate clockwize" class="color0" onclick="rotateDrawing(1);">
+                                <span class="bitsy_icon">rotate_right</span>
+                            </button>
+
+                            <button title="rotate counter-clockwize" class="color0" onclick="rotateDrawing(0);">
+                                <span class="bitsy_icon">rotate_left</span>
+                            </button>
+
+                        <!-- the grid button is here and it's hacky as all-get-out but uhhhh i love making weird html -->
+
+                            <div id="paintEditGrid">
 								<input type="checkbox" id="paintGridCheck" onclick="togglePaintGrid(event);" autocomplete="off" checked/>
 								<label title="show / hide grid" for="paintGridCheck" class="bitsy-menu-label">
 									<span id="paintGridIcon" class="bitsy_icon">visibility</span>
 									<span class="localize grid_toggle_visible">grid</span>
 								</label>
+							</div>
+                        </div>
+
+                        <div id="paintMirror" class="navControl">
+                            <button title="mirror to right" class="color0" onclick="mirrorDrawing(1);">
+                                <span class="bitsy_icon">mirror_right</span>
+                            </button>
+
+                            <button title="mirror to left" class="color0" onclick="mirrorDrawing(0);">
+                                <span class="bitsy_icon">mirror_left</span>
+                            </button>
+
+                            <button title="mirror to down" class="color0" onclick="mirrorDrawing(3);">
+                                <span class="bitsy_icon">mirror_down</span>
+                            </button>
+
+                            <button title="mirror to up" class="color0" onclick="mirrorDrawing(2);">
+                                <span class="bitsy_icon">mirror_up</span>
+                            </button>
+
+                            <button title="horizontal flip" class="color0" onclick="flipDrawing(1);">
+                                <span class="bitsy_icon">flip_horizontal</span>
+                            </button>
+
+                            <button title="vertical flip" class="color0" onclick="flipDrawing(0);">
+                                <span class="bitsy_icon">flip_vertical</span>
+                            </button>
+
+                            <!-- paint hacks end -->
+
+							<div id="paintEditInventory">
 								<button id="showInventoryButton" title="show inventory" class="bitsy-menu-label" onclick="showPanel('inventoryPanel', 'paintPanel');">
-									<span class="bitsy_icon">item</span>
+									<span class="bitsy_icon" style="margin-right: 0px;">item</span>
 									<span class="localize inventory_tool_name">inventory</span>
 								</button>
 							</div>

--- a/editor/script/editor.js
+++ b/editor/script/editor.js
@@ -595,7 +595,7 @@ function resetGameData() {
 
 function refreshGameData() {
 	if (isPlayMode) {
-		return; //never store game data while in playmode (TODO: wouldn't be necessary if the game data was decoupled form editor data)
+		return; //never store game data while in playmode (TODO: wouldn't be necessary if the game data was decoupled from editor data)
 	}
 
 	flags.ROOM_FORMAT = 1; // always save out comma separated format, even if the old format is read in
@@ -2775,7 +2775,7 @@ function importGameData(e) {
 
 	reader.onloadend = function() {
 		var gameDataStr = reader.result;
-		// gameDataStr = importer.importData( fileText );
+		// gameDataStr = importer.importData( fileText ); // since it's already the straight game data, there's no need to run it thru the import cleaner
 
 		// change game data & reload everything
 		document.getElementById("game_data").value = gameDataStr;

--- a/editor/script/paint.js
+++ b/editor/script/paint.js
@@ -286,8 +286,9 @@ function PaintTool(canvas, roomTool) {
 	function updateDrawingData() {
 		// this forces a renderer cache refresh but it's kind of wonky
 		renderer.SetImageSource(drawing.drw, getDrawingImageSource(drawing));
-		//console.log("updateDrawingData function ran");
-		events.Raise("game_data_change"); // hacky but I'm desperate
+		// console.log("updateDrawingData function ran");
+		events.Raise("game_data_refresh"); // i think this is going to get the find tool to refresh how i want
+		/* i'm pretty sure that this ^ is something the service worker is allegedly supposed to do */
 	}
 
 	// methods for updating the UI

--- a/editor/style/paintToolStyle.css
+++ b/editor/style/paintToolStyle.css
@@ -18,9 +18,6 @@
 	border-color: var(--bitsy-color-main-2);
 }
 
-.buttonGroup {
-	padding: 2px;
-	margin: 2px;
-	margin-left: 0px;
-	display: inline-block;
+.paintToolTop {
+	margin-top: var(--bitsy-space-m);
 }


### PR DESCRIPTION
editor\index.html:
- made the tile/sprite/item text box span the width of the paint tool so i can see all of the long names that i use
- put the paint transformation and mirror buttons into navControl boxes
- put the view/hide grid button in the first line of transformation buttons because that space was looking empty, and to shorten the paint panel a bit
- on that note, i also put the inventory button (that shows up when working in the item tab) in line with the mirror buttons
-- the word is too long and probably looks pretty hacky on some platforms, but as of rn i've never used the inventory feature, so it works just fine for me

paintToolStyle.css:
- added some CSS to accommodate the above adjustments to the HTML

editor.js:
- fixed a typo
- added a comment

paint.js:
- changed the event raised by the updateDrawingData function from "game_data_change" to "game_data_refresh", which i think /should/ be more gentle on the overall program? we'll see