### PR TITLE
added option to toggle transparent sprites hack on/off

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -146,6 +146,12 @@
 					<span class="bitsy_icon icon_space_right">item</span>
 					<span class="localize inventory_tool_name">inventory</span>
 				</label>
+
+				<input type="checkbox" value="downloadPanel" id="downloadCheck" onclick="togglePanelAnimated(event);" autocomplete="off" />
+				<label title="show / hide download window" for="downloadCheck">
+					<span class="bitsy_icon icon_space_right">file</span>
+					<span class="localize download_tool_name">download</span>
+				</label>
 				
 				<input type="checkbox" value="gifPanel" id="gifCheck" onclick="togglePanelAnimated(event);" autocomplete="off" />
 				<label title="show / hide gif recording window" for="gifCheck">
@@ -1067,6 +1073,153 @@
 					</div>
 				</div>
 
+				<!-- #Download -->
+				<div id="downloadPanel" class="bitsy-card bitsy-card-s bitsy-workbench-item" style="display:none;">
+					<div class="bitsy-card-titlebar">
+						<span class="bitsy_icon">file</span>
+
+						<span class="bitsy-card-title" title="download window" onmousedown="grabCard(event);">
+							<span class="localize download_tool_name">download</span>
+						</span>
+
+						<button title="minimize download window" onclick="hidePanel('downloadPanel');">
+							<span class="bitsy_icon">close</span>
+						</button>
+					</div>
+
+					<div class="bitsy-card-main bitsy-settings-group">
+						<div style="margin-bottom: var(--bitsy-space-s);">
+							<span class="localize download_html" style="margin-bottom: var(--bitsy-space-s);">download game as html file:</span>
+							<br>
+							<button title="download game as html file" class="color0" onclick="exportGame();">
+								<span class="bitsy_icon">download</span>
+								<span class="localize download_game">download game</span>
+							</button>
+						</div>
+
+						<div style="margin-bottom: var(--bitsy-space-s);">
+							<span class="localize import_html" style="margin-bottom: var(--bitsy-space-s);">import game from html file:</span>
+							<br style="margin-bottom: var(--bitsy-space-s);">
+							<label for="importGamePicker" class="filePickerLabel" title="import game from html file on your computer">
+								<span class="bitsy_icon">upload</span>
+								<span class="localize upload_game">upload game</span>
+							</label>
+							<input type="file" id="importGamePicker" style="display:none;" onchange="importGameFromFile(event);"/>
+						</div>
+
+						<!-- TODO LOCALIZE - word wrap -->
+						<div id="downloadHelp" class="helpMessage" style="display:none;">
+							Note: your browser doesn't support<br>
+							direct downloads, so sharing requires<br>
+							some extra steps:<br>
+							- press share <br>
+							- a new tab will open <br>
+							- save that tab <br>
+							- name it "mygame.html" <br>
+							- share your game as a web page!
+						</div>
+
+						<div id="settingsInner">
+							<div>
+								<span class="localize game_settings">game settings</span>
+							</div>
+							
+							<div class="controlBox">
+								<span class="localize option_page_color">html page color:</span>
+								<br/>
+								<input title="pick background color for exported html page" type="color" value="#ffffff" id="pageColor" autocomplete="off" onchange="on_change_color_page();">
+							</div>
+							
+							<div class="controlBox">
+								<form>
+									<span class="localize option_window_size">game window size:</span>
+									<br/>
+									<input type="radio" name="export size" value="full" onclick="chooseExportSizeFull();" id="exportSizeOptionFull">
+									<label title="game window resizes to fill page (mobile friendly)" for="exportSizeOptionFull" class="left">
+										<span class="bitsy_icon">pagesize_full</span>
+										<span class="localize option_full_size">full page</span>
+									</label>
+
+									<input type="radio" name="export size" value="fixed" onclick="chooseExportSizeFixed();" id="exportSizeOptionFixed" checked>
+									<label title="game window stays a fixed size" for="exportSizeOptionFixed" class="right">
+										<span class="bitsy_icon">pagesize_fixed</span>
+										<span class="localize option_fixed_size">fixed size</span>
+									</label>
+
+									<div style="margin-top:5px;">
+										<span class="controlBox" id="exportSizeFixedInputSpan"><!-- style="display:none;"-->
+											<input type="number" min="0" value="512" style="width:60px;" id="exportSizeFixedInput"> px
+										</span>
+									</div>
+								</form>
+							</div>
+
+							<div class="controlBox">
+								<span class="localize font_label">font</span>:
+									<select id="fontSelect" onchange="on_change_font(event);">
+										<option value="ascii_small" class="localize font_ascii_small">ASCII Small</option>
+										<option value="unicode_european_small" class="localize font_unicode_european_small">Unicode European Small</option>
+										<option value="unicode_european_large" class="localize font_unicode_european_large">Unicode European Large</option>
+										<option value="unicode_asian" class="localize font_unicode_asian">Unicode Asian</option>
+										<option value="arabic" class="localize font_arabic">Arabic</option>
+										<option value="custom">Custom Font - none</option> <!-- TODO : localize -->
+									</select>
+								<div id="ascii_small_description" style="font-size: 80%">
+									<span class="localize font_ascii_small_description">Small font limited to ASCII, which includes English characters and some symbols.</span>
+								</div>
+								<div id="unicode_european_small_description" style="font-size: 80%">
+									<span class="localize font_unicode_european_small_description">Small font with some unicode support. Includes characters for most European languages.</span>
+								</div>
+								<div id="unicode_european_large_description" style="font-size: 80%">
+									<span class="localize font_unicode_european_large_description">Large font with more unicode support. Includes characters for all European languages.</span>
+								</div>
+								<div id="unicode_asian_description" style="font-size: 80%">
+									<span class="localize font_unicode_asian_description">Large font which includes characters for Asian languages such as Chinese, Japanese, and Korean.</span>
+								</div>
+								<div id="arabic_description" style="font-size: 80%">
+									<span class="localize font_arabic_description">Pixel font with Arabic characters</span>
+								</div>
+								<div id="custom_description" style="font-size: 80%">
+									<span class="localize font_custom_description">Upload your own custom font in the ".bitsyfont" format!</span>
+									<br/>
+									<label for="importFontPicker" class="filePickerLabel" title="import font from bitsyfont file on your computer">
+										<span class="bitsy_icon">upload</span>
+										<span class="localize upload_font">upload font</span>
+									</label>
+									<input title="import font from bitsyfont file on your computer" type="file" id="importFontPicker" style="display:none;" onchange="importFontFromFile(event);"/>
+								</div>
+								<div style="margin-top:3px;">
+									<button title="download font file" class="color0" onclick="exportFont();">
+										<span class="bitsy_icon">download</span>
+										<span class="localize download_font">download font</span>
+									</button>
+								</div>
+								<div>
+									<span class="localize text_direction_label">text direction</span>:
+									<select id="textDirectionSelect" onchange="on_change_text_direction(event);">
+										<option value="LTR" class="localize text_direction_ltr">Left to Right</option>
+										<option value="RTL" class="localize text_direction_rtl">Right to Left</option>
+									</select>
+								</div>
+								<div style="font-size: 80%">
+									<span class="localize text_direction_description">Option for languages that read right to left</span>
+								</div>
+							</div>
+
+							<div class="controlBox">
+								<span class="hacks_toggle_label">hacks</span>:
+								<input type="checkbox" id="transparentSpritesCheck" onclick="toggleTransparentSprites(event);" autocomplete="off" checked/>
+								<label title="hack on / off" for="transparentSpritesCheck" class="bitsy-menu-label">
+									<span id="transparentSpritesIcon" class="bitsy_icon">visibility</span>
+									<span class="option_transparent_sprites">transparent sprites</span>
+								</label>
+							</div>
+						</div>
+					</div>
+				</div>
+					</div>
+				</div>
+
 				<!-- #Record GIF #gif -->
 				<div id="gifPanel" class="bitsy-card bitsy-card-m bitsy-workbench-item" style="display:none;">
 					<div class="bitsy-card-titlebar">
@@ -1128,7 +1281,7 @@
 					</div>
 				</div>
 
-				<!-- #Game Data and #Download -->
+				<!-- #Game Data -->
 				<div id="dataPanel" class="bitsy-card bitsy-card-m bitsy-workbench-item" style="display:none;">
 					<div class="bitsy-card-titlebar">
 						<span class="bitsy_icon">game_data</span>
@@ -1167,43 +1320,10 @@
 							</label>
 						</div>
 					</div>
-
-					<div class="bitsy-card-main">
-						<div style="margin-bottom: var(--bitsy-space-s);">
-							<span class="localize download_html" style="margin-bottom: var(--bitsy-space-s);">download game as html file:</span>
-							<br>
-							<button title="download game as html file" class="color0" onclick="exportGame();">
-								<span class="bitsy_icon">download</span>
-								<span class="localize download_game">download game</span>
-							</button>
-						</div>
-
-						<div style="margin-bottom: var(--bitsy-space-s);">
-							<span class="localize import_html" style="margin-bottom: var(--bitsy-space-s);">import game from html file:</span>
-							<br style="margin-bottom: var(--bitsy-space-s);">
-							<label for="importGamePicker" class="filePickerLabel" title="import game from html file on your computer">
-								<span class="bitsy_icon">upload</span>
-								<span class="localize upload_game">upload game</span>
-							</label>
-							<input type="file" id="importGamePicker" style="display:none;" onchange="importGameFromFile(event);"/>
-						</div>
-
-						<!-- TODO LOCALIZE - word wrap -->
-						<div id="downloadHelp" class="helpMessage" style="display:none;">
-							Note: your browser doesn't support<br>
-							direct downloads, so sharing requires<br>
-							some extra steps:<br>
-							- press share <br>
-							- a new tab will open <br>
-							- save that tab <br>
-							- name it "mygame.html" <br>
-							- share your game as a web page!
-						</div>
-					</div>
 				</div>
 
 				<!-- #Settings -->
-				<div id="settingsPanel" class="bitsy-card bitsy-card-s bitsy-workbench-item" style="display:none;">
+				<div id="settingsPanel" class="bitsy-card bitsy-card-xs bitsy-workbench-item" style="display:none;">
 					<div class="bitsy-card-titlebar">
 						<span class="bitsy_icon">settings</span>
 
@@ -1225,89 +1345,6 @@
 							<select id="languageSelect" onchange="on_change_language(event);"></select>
 							<br/>
 							<span class="localize language_translator_credit" style="font-size: 80%;">English text by Adam Le Doux</span>
-						</div>
-						<div>
-							<span class="localize game_settings">game settings</span>
-						</div>
-						<div class="controlBox">
-							<span class="localize option_page_color">html page color:</span>
-							<br/>
-							<input title="pick background color for exported html page" type="color" value="#ffffff" id="pageColor" autocomplete="off" onchange="on_change_color_page();">
-							<!-- TODO: i want the background to always be white in the browser editor -->
-						</div>
-						<div class="controlBox">
-							<form>
-								<span class="localize option_window_size">game window size:</span>
-								<br/>
-								<input type="radio" name="export size" value="full" onclick="chooseExportSizeFull();" id="exportSizeOptionFull" checked>
-								<label title="game window resizes to fill page (mobile friendly)" for="exportSizeOptionFull" class="left">
-									<span class="bitsy_icon">pagesize_full</span>
-									<span class="localize option_full_size">full page</span>
-								</label>
-
-								<input type="radio" name="export size" value="fixed" onclick="chooseExportSizeFixed();" id="exportSizeOptionFixed">
-								<label title="game window stays a fixed size" for="exportSizeOptionFixed" class="right">
-									<span class="bitsy_icon">pagesize_fixed</span>
-									<span class="localize option_fixed_size">fixed size</span>
-								</label>
-
-								<div style="margin-top:5px;">
-									<span class="controlBox" id="exportSizeFixedInputSpan"> <!-- style="display:none;" -->
-										<input type="number" min="0" value="512" style="width:60px;" id="exportSizeFixedInput"> px
-									</span>
-								</div>
-							</form>
-						</div>
-						<div class="controlBox">
-							<span class="localize font_label">font</span>:
-							<select id="fontSelect" onchange="on_change_font(event);">
-								<option value="ascii_small" class="localize font_ascii_small">ASCII Small</option>
-								<option value="unicode_european_small" class="localize font_unicode_european_small">Unicode European Small</option>
-								<option value="unicode_european_large" class="localize font_unicode_european_large">Unicode European Large</option>
-								<option value="unicode_asian" class="localize font_unicode_asian">Unicode Asian</option>
-								<option value="arabic" class="localize font_arabic">Arabic</option>
-								<option value="custom">Custom Font - none</option> <!-- TODO : localize -->
-							</select>
-							<div id="ascii_small_description" style="font-size: 80%">
-								<span class="localize font_ascii_small_description">Small font limited to ASCII, which includes English characters and some symbols.</span>
-							</div>
-							<div id="unicode_european_small_description" style="font-size: 80%">
-								<span class="localize font_unicode_european_small_description">Small font with some unicode support. Includes characters for most European languages.</span>
-							</div>
-							<div id="unicode_european_large_description" style="font-size: 80%">
-								<span class="localize font_unicode_european_large_description">Large font with more unicode support. Includes characters for all European languages.</span>
-							</div>
-							<div id="unicode_asian_description" style="font-size: 80%">
-								<span class="localize font_unicode_asian_description">Large font which includes characters for Asian languages such as Chinese, Japanese, and Korean.</span>
-							</div>
-							<div id="arabic_description" style="font-size: 80%">
-								<span class="localize font_arabic_description">Pixel font with Arabic characters</span>
-							</div>
-							<div id="custom_description" style="font-size: 80%">
-								<span class="localize font_custom_description">Upload your own custom font in the ".bitsyfont" format!</span>
-								<br/>
-								<label for="importFontPicker" class="filePickerLabel" title="import font from bitsyfont file on your computer">
-									<span class="bitsy_icon">upload</span>
-									<span class="localize upload_font">upload font</span>
-								</label>
-								<input title="import font from bitsyfont file on your computer" type="file" id="importFontPicker" style="display:none;" onchange="importFontFromFile(event);"/>
-							</div>
-							<div style="margin-top:3px;">
-								<button title="download font file" class="color0" onclick="exportFont();">
-									<span class="bitsy_icon">download</span>
-									<span class="localize download_font">download font</span>
-								</button>
-							</div>
-							<div>
-								<span class="localize text_direction_label">text direction</span>:
-								<select id="textDirectionSelect" onchange="on_change_text_direction(event);">
-									<option value="LTR" class="localize text_direction_ltr">Left to Right</option>
-									<option value="RTL" class="localize text_direction_rtl">Right to Left</option>
-								</select>
-							</div>
-							<div style="font-size: 80%">
-								<span class="localize text_direction_description">Option for languages that read right to left</span>
-							</div>
 						</div>
 					</div>
 				</div>

--- a/editor/script/editor.js
+++ b/editor/script/editor.js
@@ -2228,7 +2228,8 @@ function exportGame() {
 		export_settings.page_color,
 		filenameFromGameTitle() + ".html",
 		isFixedSize,
-		size);
+		size,
+		transparentHackState);
 }
 
 function exportGameData() {
@@ -3312,7 +3313,7 @@ function togglePreviewDialog(event) {
 	updatePreviewDialogButton();
 }
 
-var isFixedSize = false;
+var isFixedSize = true;
 function chooseExportSizeFull() {
 	isFixedSize = false;
 	document.getElementById("exportSizeFixedInputSpan").style.display = "none";
@@ -3321,6 +3322,17 @@ function chooseExportSizeFull() {
 function chooseExportSizeFixed() {
 	isFixedSize = true;
 	document.getElementById("exportSizeFixedInputSpan").style.display = "inline-block";
+}
+
+// trans-prites hack
+var transparentHackState = true;
+function toggleTransparentSprites(e) {
+	if (e.target.checked) {
+		transparentHackState = true;
+	}
+	else {
+		transparentHackState = false;
+	}
 }
 
 // LOCALIZATION
@@ -3332,7 +3344,7 @@ function on_change_language(e) {
 }
 
 function on_change_language_inner(language) {
-	changeLnaguageStyle(language); // TODO : misspelled funciton name
+	changeLanguageStyle(language);
 
 	localization.ChangeLanguage(language);
 	updateInventoryUI();
@@ -3379,7 +3391,7 @@ function hackyUpdatePlaceholderText() {
 }
 
 var curEditorLanguageCode = "en";
-function changeLnaguageStyle(newCode) { // TODO : fix function name
+function changeLanguageStyle(newCode) {
 	document.body.classList.remove("lang_" + curEditorLanguageCode);
 	curEditorLanguageCode = newCode;
 	document.body.classList.add("lang_" + curEditorLanguageCode);

--- a/editor/script/exporter.js
+++ b/editor/script/exporter.js
@@ -12,7 +12,7 @@ function replaceTemplateMarker(template, marker, text) {
 	return template.substr( 0, markerIndex ) + text + template.substr( markerIndex + marker.length );
 }
 
-this.exportGame = function(gameData, title, pageColor, filename, isFixedSize, size) {
+this.exportGame = function(gameData, title, pageColor, filename, isFixedSize, size, transparentHackState) {
 	var html = Resources["exportTemplate.html"].substr(); //copy template
 	// bitsyLog(html, "editor");
 
@@ -36,8 +36,14 @@ this.exportGame = function(gameData, title, pageColor, filename, isFixedSize, si
 	html = replaceTemplateMarker( html, "@@L", Resources["dialog.js"] );
 	html = replaceTemplateMarker( html, "@@R", Resources["renderer.js"] );
 	html = replaceTemplateMarker( html, "@@E", Resources["bitsy.js"] );
+
 	// bake in hacks
-	html = replaceTemplateMarker( html, "@@A", Resources["transparent-sprites.js"] );
+	if( transparentHackState ) {
+		html = replaceTemplateMarker( html, "@@A", Resources["transparent-sprites.js"] );
+	}
+	else {
+		html = replaceTemplateMarker( html, "@@A", "" );
+	}
 	
 	// export the default font in its own script tag (TODO : remove if unused)
 	html = replaceTemplateMarker( html, "@@N", "ascii_small" );

--- a/editor/style/settingsToolStyle.css
+++ b/editor/style/settingsToolStyle.css
@@ -5,3 +5,9 @@
 #settingsInner {
 	white-space: normal;
 }
+
+.bitsy-settings-group {
+	display: flex;
+	flex-wrap: wrap;
+	overflow: visible;
+}


### PR DESCRIPTION
editor\index.html:
- added back in download panel + accompanying toolbar tab
- moved download buttons back to download panel from game data panel
- moved game settings from settings panel into download panel
- moved "checked" attribute from full-sized export option to fixed-size export option
- made the pixel size box visible as default for the fixed-size export option
- added a button to toggle the transparent sprites hack on/off
- changed the settings panel bitsy-card size from s to xs

editor\script\editor.js:
- added transparent sprites toggle variable to exportGame function
- made fixed-size export the default
- created variable and function to toggle the transparent sprites hack on/off
- fixed a function-name typo

editor\script\exporter.js:
- added transparent sprites toggle variable to exportGame function
- added if/else for the transparent sprites hack

editor\style\settingsToolStyle.css:
- added bitsy-settings-group class to mimic the purpose of the bitsy-menu-group class but with fewer attributes